### PR TITLE
fix: update submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://gitlab.com/qemu-project/dtc.git
 [submodule "roms/u-boot"]
 	path = roms/u-boot
-	url = https://gitlab.com/qemu-project/u-boot.git
+	url = https://gitlab.com/qemu-project-mirrors/u-boot.git
 [submodule "roms/skiboot"]
 	path = roms/skiboot
 	url = https://gitlab.com/qemu-project/skiboot.git
@@ -39,7 +39,7 @@
 	url = https://gitlab.com/qemu-project/seabios-hppa.git
 [submodule "roms/u-boot-sam460ex"]
 	path = roms/u-boot-sam460ex
-	url = https://gitlab.com/qemu-project/u-boot-sam460ex.git
+	url = https://gitlab.com/qemu-project-mirrors/u-boot-sam460ex.git
 [submodule "tests/fp/berkeley-testfloat-3"]
 	path = tests/fp/berkeley-testfloat-3
 	url = https://gitlab.com/qemu-project/berkeley-testfloat-3.git


### PR DESCRIPTION
The repositories corresponding to the `roms/u-boot` and `roms/u-boot-sam460ex` submodules have been moved to a different GitLab group (i.e., from [qemu-project](https://gitlab.com/qemu-project) to [qemu-project-mirrors](https://gitlab.com/qemu-project-mirrors)).

Therefore, running `git submodule update --init --recursive` as instructed in the [`README`](https://github.com/Ember-IO/Ember-IO-Fuzzing/blob/main/README.md) for [Ember-IO/Ember-IO-Fuzzing](https://github.com/Ember-IO/Ember-IO-Fuzzing) fails.

This PR updates the URLs of the affected submodules to resolve the breakage in this repository.

However, to resolve the issue fully, it would also be necessary to bump the submodules in [Ember-IO/AFLplusplus](https://github.com/Ember-IO/AFLplusplus) and [Ember-IO/Ember-IO-Fuzzing](https://github.com/Ember-IO/Ember-IO-Fuzzing) as well.